### PR TITLE
feat: add graphql support

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -2,12 +2,14 @@
 
 namespace pohnean\currencyfield;
 
+use craft\events\RegisterGqlTypesEvent;
 use craft\events\RegisterComponentTypesEvent;
+use craft\services\Gql;
 use craft\services\Fields;
-use craft\web\twig\variables\CraftVariable;
-use pohnean\currencyfield\fields\CurrencyField;
-use pohnean\currencyfield\variables\CurrencyFieldVariable;
 use yii\base\Event;
+
+use pohnean\currencyfield\fields\CurrencyField;
+use pohnean\currencyfield\gql\types\fields\CurrencyField as CurrencyFieldType;
 
 /**
  * Class Currencyselect
@@ -53,5 +55,13 @@ class Plugin extends \craft\base\Plugin
 				$event->types[] = CurrencyField::class;
 			}
 		);
+
+		Event::on(
+            Gql::class,
+            Gql::EVENT_REGISTER_GQL_TYPES,
+            function (RegisterGqlTypesEvent $event) {
+                $event->types[] = CurrencyFieldType::class;
+            }
+        );
 	}
 }

--- a/src/fields/CurrencyField.php
+++ b/src/fields/CurrencyField.php
@@ -2,16 +2,19 @@
 
 namespace pohnean\currencyfield\fields;
 
-use CommerceGuys\Intl\Currency\Currency;
-use CommerceGuys\Intl\Currency\CurrencyRepository;
 use Craft;
 use craft\base\Element;
 use craft\base\ElementInterface;
 use craft\base\Field;
 use craft\base\PreviewableFieldInterface;
 use craft\base\SortableFieldInterface;
-use pohnean\currencyfield\models\CurrencyData;
 use yii\db\Schema;
+
+use CommerceGuys\Intl\Currency\Currency;
+use CommerceGuys\Intl\Currency\CurrencyRepository;
+
+use pohnean\currencyfield\gql\resolvers\fields\CurrencyField as CurrencyFieldResolver;
+use pohnean\currencyfield\gql\types\fields\CurrencyField as CurrencyFieldType;
 
 class CurrencyField extends Field implements PreviewableFieldInterface, SortableFieldInterface
 {
@@ -27,6 +30,18 @@ class CurrencyField extends Field implements PreviewableFieldInterface, Sortable
 	{
 		return Schema::TYPE_STRING . '(3)';
 	}
+
+	/**
+     * @inheritdoc
+     */
+    public function getContentGqlType()
+    {
+        return [
+            'name' => $this->handle,
+            'type' => CurrencyFieldType::getType(),
+            'resolve' => CurrencyFieldResolver::class . '::resolve',
+        ];
+    }
 
 	/**
 	 * @inheritdoc

--- a/src/fields/CurrencyField.php
+++ b/src/fields/CurrencyField.php
@@ -13,6 +13,7 @@ use yii\db\Schema;
 use CommerceGuys\Intl\Currency\Currency;
 use CommerceGuys\Intl\Currency\CurrencyRepository;
 
+use pohnean\currencyfield\gql\arguments\fields\CurrencyField as CurrencyFieldArguments;
 use pohnean\currencyfield\gql\resolvers\fields\CurrencyField as CurrencyFieldResolver;
 use pohnean\currencyfield\gql\types\fields\CurrencyField as CurrencyFieldType;
 
@@ -39,6 +40,7 @@ class CurrencyField extends Field implements PreviewableFieldInterface, Sortable
         return [
             'name' => $this->handle,
             'type' => CurrencyFieldType::getType(),
+			'args' => CurrencyFieldArguments::getArguments(),
             'resolve' => CurrencyFieldResolver::class . '::resolve',
         ];
     }

--- a/src/gql/arguments/fields/CurrencyField.php
+++ b/src/gql/arguments/fields/CurrencyField.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace pohnean\currencyfield\gql\arguments\fields;
+
+use GraphQL\Type\Definition\Type;
+
+class CurrencyField extends \craft\gql\base\Arguments
+{
+    public static function getArguments(): array
+    {
+        // append our argument to common element arguments and any from custom fields
+        return array_merge(
+            parent::getArguments(), [
+            'locale' => [
+            'name' => 'locale',
+            'type' => Type::string(),
+            'description' => 'Format the currency in a different locale.'
+            ]]
+        );
+    }
+}

--- a/src/gql/resolvers/fields/CurrencyField.php
+++ b/src/gql/resolvers/fields/CurrencyField.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace pohnean\currencyfield\gql\resolvers\fields;
+
+use \craft\gql\base\Resolver;
+use GraphQL\Type\Definition\ResolveInfo;
+
+class CurrencyField extends Resolver
+{
+    public static function resolve($source, array $arguments, $context, ResolveInfo $resolveInfo)
+    {
+        $fieldName = $resolveInfo->fieldName;
+        $optionFieldData = $source->{$fieldName};
+
+        return [
+            'name' => $optionFieldData->getName(),
+            'currencyCode' => $optionFieldData->getCurrencyCode(),
+            'symbol' => $optionFieldData->getSymbol(),
+            'numericCode' => $optionFieldData->getNumericCode(),
+            'locale' => $optionFieldData->getLocale(),
+            'fractionDigits' => $optionFieldData->getFractionDigits()
+        ];
+    }
+}

--- a/src/gql/resolvers/fields/CurrencyField.php
+++ b/src/gql/resolvers/fields/CurrencyField.php
@@ -4,21 +4,27 @@ namespace pohnean\currencyfield\gql\resolvers\fields;
 
 use \craft\gql\base\Resolver;
 use GraphQL\Type\Definition\ResolveInfo;
+use CommerceGuys\Intl\Currency\CurrencyRepository;
 
 class CurrencyField extends Resolver
 {
     public static function resolve($source, array $arguments, $context, ResolveInfo $resolveInfo)
     {
         $fieldName = $resolveInfo->fieldName;
-        $optionFieldData = $source->{$fieldName};
+        $currency = $source->{$fieldName};
+
+        if (!empty($arguments['locale'])) {
+            $currencyRepository = new CurrencyRepository;
+            $currency = $currencyRepository->get($currency->getCurrencyCode(), $arguments['locale']);
+        }
 
         return [
-            'name' => $optionFieldData->getName(),
-            'currencyCode' => $optionFieldData->getCurrencyCode(),
-            'symbol' => $optionFieldData->getSymbol(),
-            'numericCode' => $optionFieldData->getNumericCode(),
-            'locale' => $optionFieldData->getLocale(),
-            'fractionDigits' => $optionFieldData->getFractionDigits()
+            'name' => $currency->getName(),
+            'currencyCode' => $currency->getCurrencyCode(),
+            'symbol' => $currency->getSymbol(),
+            'numericCode' => $currency->getNumericCode(),
+            'locale' => $currency->getLocale(),
+            'fractionDigits' => $currency->getFractionDigits()
         ];
     }
 }

--- a/src/gql/types/fields/CurrencyField.php
+++ b/src/gql/types/fields/CurrencyField.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace pohnean\currencyfield\gql\types\fields;
+
+use craft\gql\TypeManager;
+use craft\gql\GqlEntityRegistry;
+use GraphQL\Type\Definition\Type;
+use GraphQL\Type\Definition\ObjectType;
+use \craft\gql\base\ObjectType as CraftObjectType;
+
+class CurrencyField extends CraftObjectType
+{
+    public static function getName(): string
+    {
+        return 'CurrencyField';
+    }
+
+    public static function getType(): Type
+    {
+        // Return the type if it’s already been created
+        if ($type = GqlEntityRegistry::getEntity(self::getName())) {
+            return $type;
+        }
+
+        // Otherwise create the type via the entity registry, which handles prefixing
+        return GqlEntityRegistry::createEntity(
+            self::getName(), new ObjectType(
+                [
+                'name' => static::getName(),
+                'fields' => self::class . '::getFieldDefinitions',
+                'description' => 'This is the interface implemented by all currency fields.',
+                'resolveType' => self::class . '::resolveElementTypeName',
+                ]
+            )
+        );
+    }
+
+    public static function resolveElementTypeName()
+    {
+        return GqlEntityRegistry::prefixTypeName(self::getName());
+    }
+
+    public static function getFieldDefinitions(): array
+    {
+        // Add our custom widget’s field to common ones for all elements
+        return TypeManager::prepareFieldDefinitions(
+            [
+                'name' => [
+                    'name' => 'name',
+                    'type' => Type::string(),
+                    'description' => 'Gets the currency name.'
+                ],
+                'currencyCode' => [
+                    'name' => 'currencyCode',
+                    'type' => Type::string(),
+                    'description' => 'Gets the alphabetic currency code.'
+                ],
+                'symbol' => [
+                    'name' => 'symbol',
+                    'type' => Type::string(),
+                    'description' => 'Gets the currency symbol.'
+                ],
+                'numericCode' => [
+                    'name' => 'numericCode',
+                    'type' => Type::string(),
+                    'description' => 'The numeric currency code.'
+                ],
+                'locale' => [
+                    'name' => 'locale',
+                    'type' => Type::string(),
+                    'description' => 'The locale (i.e. "en_US").'
+                ],
+                'fractionDigits' => [
+                    'name' => 'fractionDigits',
+                    'type' => Type::int(),
+                    'description' => 'The number of fraction digits.'
+                ],
+            ], self::getName()
+        );
+    }
+}


### PR DESCRIPTION
I've added in GraphQL support so that the following Currency attributes can be queried:

- name
- currencyCode
- symbol
- numericCode
- locale
- fractionDigits

I've also added an argument so that different locales can be used if wanted.

<img width="1791" alt="Screen Shot 2021-07-26 at 12 56 00 PM" src="https://user-images.githubusercontent.com/5515179/126919659-fe358a8b-1e65-447c-b850-7248e8817d82.png">
